### PR TITLE
Set default configuration to be prometheus-only

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 PORT=8000
-TSDB_CONN='postgres://<postgres user>:<postgres password>@localhost:5432/tsdb'
+TSDB_CONN=''
 CONFIG_FULL_PATH='/usr/src/polkadot-prom-exporter/config.json'
 

--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 PORT=8000
 TSDB_CONN='postgres://<postgres user>:<postgres password>@localhost:5432/tsdb'
-CONFIG_FULL_PATH='<the full path of config.json>'
+CONFIG_FULL_PATH='/usr/src/polkadot-prom-exporter/config.json'
 


### PR DESCRIPTION
This fixes the default configuration of the docker image, allowing it to run without a database connection.